### PR TITLE
[BUGFIX] Redis Inmem cache Remove and Flush methods should propagate

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,13 +16,16 @@ require (
 	github.com/hashicorp/golang-lru v0.6.0
 	github.com/jellydator/ttlcache/v2 v2.11.1
 	github.com/redis/go-redis/v9 v9.4.0
+	github.com/tangelo-labs/go-domain v0.0.7
 )
 
 require (
 	github.com/alicebob/gopher-json v0.0.0-20200520072559-a9ecdc9d1d3a // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
+	github.com/google/uuid v1.3.0 // indirect
 	github.com/kr/pretty v0.3.1 // indirect
+	github.com/oklog/ulid/v2 v2.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rogpeppe/go-internal v1.10.0 // indirect
 	github.com/yuin/gopher-lua v1.1.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/tangelo-labs/go-cache
 
-go 1.20
+go 1.21
 
 // Deps
 require (

--- a/go.sum
+++ b/go.sum
@@ -23,6 +23,8 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/hashicorp/golang-lru v0.6.0 h1:uL2shRDx7RTrOrTCUZEGP/wJUFiUI8QT6E7z5o8jga4=
 github.com/hashicorp/golang-lru v0.6.0/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/jellydator/ttlcache/v2 v2.11.1 h1:AZGME43Eh2Vv3giG6GeqeLeFXxwxn1/qHItqWZl6U64=
@@ -35,6 +37,9 @@ github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
+github.com/oklog/ulid/v2 v2.1.0 h1:+9lhoxAP56we25tyYETBBY1YLA2SaoLvUFgrP2miPJU=
+github.com/oklog/ulid/v2 v2.1.0/go.mod h1:rcEKHmBBKfef9DhnvX7y1HZBYxjXb0cP5ExxNsTT1QQ=
+github.com/pborman/getopt v0.0.0-20170112200414-7148bc3a4c30/go.mod h1:85jBQOZwpVEaDAr341tbn15RS4fCAsIst0qp7i8ex1o=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
@@ -48,6 +53,8 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+github.com/tangelo-labs/go-domain v0.0.7 h1:/LGIVUbyhXH3FFBBXhpl4XAecWGCvRk+AO9/CQXDkQ8=
+github.com/tangelo-labs/go-domain v0.0.7/go.mod h1:OQs8mEMduf7DmyqCEGLGxThjdrsbq2hCQj3VIOlneDs=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yuin/gopher-lua v1.1.0 h1:BojcDhfyDWgU2f2TOzYK/g5p2gxMrku8oupLDqlnSqE=

--- a/go.sum
+++ b/go.sum
@@ -8,7 +8,9 @@ github.com/allegro/bigcache v1.2.1/go.mod h1:Cb/ax3seSYIx7SuZdm2G2xzfwmv3TPSk2uc
 github.com/brianvoe/gofakeit/v6 v6.27.0 h1:rI6rhEtXnMfdRHc1pE1tdXN/LRnDlRzFZXL2ArDV3Wk=
 github.com/brianvoe/gofakeit/v6 v6.27.0/go.mod h1:Xj58BMSnFqcn/fAQeSK+/PLtC5kSb7FJIq4JyGa8vEs=
 github.com/bsm/ginkgo/v2 v2.12.0 h1:Ny8MWAHyOepLGlLKYmXG4IEkioBysk6GpaRTLC8zwWs=
+github.com/bsm/ginkgo/v2 v2.12.0/go.mod h1:SwYbGRRDovPVboqFv0tPTcG1sN61LM1Z4ARdbAV9g4c=
 github.com/bsm/gomega v1.27.10 h1:yeMWxP2pV2fG3FgAODIY8EiRE3dy0aeFYt4l7wh6yKA=
+github.com/bsm/gomega v1.27.10/go.mod h1:JyEr/xRbxbtgWNi8tIEVPUYZ5Dzef52k01W3YH0H+O0=
 github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=
 github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=

--- a/provider/mcache/ttl.go
+++ b/provider/mcache/ttl.go
@@ -72,7 +72,11 @@ func (t *ttlWrapper[T]) Remove(_ context.Context, key string) (bool, error) {
 		return false, err
 	}
 
-	return exists, t.inner.Remove(key)
+	if err := t.inner.Remove(key); err != nil {
+		return false, err
+	}
+
+	return exists, nil
 }
 
 func (t *ttlWrapper[T]) Flush(_ context.Context) error {

--- a/provider/rsmcache/lru.go
+++ b/provider/rsmcache/lru.go
@@ -155,6 +155,7 @@ func (c *lruWrapper[T]) Flush(ctx context.Context) error {
 	pipe := c.client.TxPipeline()
 
 	key := flushCmd
+
 	c.inner.Purge()
 
 	msgRaw, err := c.envelopeEncoder.Encode(&envelope{
@@ -232,8 +233,6 @@ func (c *lruWrapper[T]) run() {
 // key that was changed. Then it tries to get the value for that key and decode
 // it using the encoder.
 func (c *lruWrapper[T]) resolveValue(sValue []byte) (T, error) {
-	var result T
-
 	result, err := c.encoder.Decode(sValue)
 	if err != nil {
 		return result, fmt.Errorf("%w: error decoding value `%s`, details = %w", cache.ErrDecoding, sValue, err)

--- a/provider/rsmcache/lru.go
+++ b/provider/rsmcache/lru.go
@@ -243,8 +243,6 @@ func (c *lruWrapper[T]) resolveValue(sValue []byte) (T, error) {
 }
 
 func (c *lruWrapper[T]) resolveEnvelope(m *redis.Message) (*envelope, error) {
-	env := &envelope{}
-
 	env, err := c.envelopeEncoder.Decode([]byte(m.Payload))
 	if err != nil {
 		return env, fmt.Errorf("%w: error decoding envelope `%s`, details = %w", cache.ErrDecoding, m.Payload, err)

--- a/provider/rsmcache/lru_test.go
+++ b/provider/rsmcache/lru_test.go
@@ -154,7 +154,7 @@ func TestLRU_Concurrency(t *testing.T) {
 
 			require.NoError(t, cacheOne.Flush(ctx))
 
-			t.Run("THEN then all keys are deleted from all caches", func(t *testing.T) {
+			t.Run("THEN all keys are deleted from all caches", func(t *testing.T) {
 				require.Eventually(t, func() bool {
 					exists1, gErr := cacheOne.Has(ctx, key)
 					if gErr != nil {


### PR DESCRIPTION
Currently, these methods are not propagating the change to the other rsm caches subscribed.

Moreover, I did changes so all provider implementations behave the same when Removing caches regarding errors and output